### PR TITLE
Fix boolean property name in term replacements

### DIFF
--- a/Parasitic disease (disorder).json
+++ b/Parasitic disease (disorder).json
@@ -69,7 +69,7 @@
           {
             "existingTerm": "of $body structure$",
             "replacement": "",
-            "whenSlotAbsent": "true"
+            "slotAbsent": "true"
           }
         ]
       },

--- a/[Clinical course] contact dermatitis of [body structure] caused by [substance] (disorder) v2.json
+++ b/[Clinical course] contact dermatitis of [body structure] caused by [substance] (disorder) v2.json
@@ -47,7 +47,7 @@
       	{
       		"existingTerm": "of $body structure$",
       		"replacement": "",
-      		"whenSlotAbsent": "true"
+      		"slotAbsent": "true"
       	}
       ]
     },
@@ -59,7 +59,7 @@
       	{
       		"existingTerm": "caused by $substance$",
       		"replacement": "",
-      		"whenSlotAbsent": "true"
+      		"slotAbsent": "true"
       	}
       ]
     }

--- a/[Course] [Periods of life] [morphology] of [body structure] (disorder).json
+++ b/[Course] [Periods of life] [morphology] of [body structure] (disorder).json
@@ -47,7 +47,7 @@
         {
           "existingTerm": "$morphology$",
           "replacement": "infection",
-          "whenSlotAbsent": "true"
+          "slotAbsent": "true"
         }
       ]
     },

--- a/[Wound morphology] of [body structure] due to [event] (disorder).json
+++ b/[Wound morphology] of [body structure] due to [event] (disorder).json
@@ -37,7 +37,7 @@
 			{
 				"existingTerm": "$physicalObject$ ",
 				"replacement": "",
-				"whenSlotAbsent": "true"
+				"slotAbsent": "true"
 			}
 		]
     },
@@ -66,7 +66,7 @@
         {
           "existingTerm": " due to $event$",
           "replacement": "",
-          "whenSlotAbsent": "true"
+          "slotAbsent": "true"
         }
       ]
     }


### PR DESCRIPTION
The following boolean properties were malformed in 4 template definitions causing the template service to silently parse these values as (default) **false** because here:

https://github.com/IHTSDO/snomed-template-service/blob/3119c7b18f562c15db401c98be4224d4fded868b/src/main/java/org/ihtsdo/otf/authoringtemplate/Config.java#L44-#L48

the ObjectMapper is not instantiated with the configuration `failOnUnknownProperties(true)` like this:

```java
ObjectMapper objectMapper = Jackson2ObjectMapperBuilder
		.json()
		.failOnUnknownProperties(true)
		.serializationInclusion(JsonInclude.Include.NON_NULL)
		.dateFormat((new SimpleDateFormat("dd-MM-yyyy hh:mm:ss")))
		.build();```
