### PR TITLE
Fix invalid slot reference according to ETL v1.0 specification

### DIFF
--- a/CT guided [procedure] of [body structure] (procedure).json
+++ b/CT guided [procedure] of [body structure] (procedure).json
@@ -2,7 +2,7 @@
   "name": "CT guided [procedure] of [body structure] (procedure)",
   "domain": "<258176004 |Computerized tomography guidance (procedure)| ",
   "version": 1,
-  "logicalTemplate": "71388002 |Procedure|:   [[~1..1]] {      260686004 |Method| = 312251004 |Computed tomography imaging action|,      [[~1..1]] 405813007 |Procedure site - Direct| = [[+id(<< 442083009 |Anatomical or acquired body structure|) @procSite]],      363703001 |Has intent| = 429892002 |Guidance intent|   },   {      260686004 |Method| = [[+id (<< 129264002 |Action|) @action]],      [[~1..1]] 405813007 |Procedure site - Direct| = [[+id $procSite]]   }",
+  "logicalTemplate": "71388002 |Procedure|: [[~1..1]] { 260686004 |Method| = 312251004 |Computed tomography imaging action|, [[~1..1]] 405813007 |Procedure site - Direct| = [[+id(<< 442083009 |Anatomical or acquired body structure|) @procSite]], 363703001 |Has intent| = 429892002 |Guidance intent| }, { 260686004 |Method| = [[+id (<< 129264002 |Action|) @action]], [[~1..1]] 405813007 |Procedure site - Direct| = [[+id(<< 442083009 |Anatomical or acquired body structure|) @procSite]] }",
   "conceptOutline": {
     "descriptions": [
       {


### PR DESCRIPTION
All existing template definitions in this repository are using the ETL v0.2 specification where the following grammar element was allowed:

```
templateSlotInfo = [cardinality ws] [templateSlotName ws] [templateSlotReference ws]
templateSlotName = "@" templateString
> templateSlotReference = "$" templateString
```

The `templateSlotReference` grammar element was however removed from the final language specification currently available. 

The current specification looks like this:

```
templateSlot =  templateReplacementSlot / templateInformationSlot
templateReplacementSlot = conceptReplacementSlot / expressionReplacementSlot / tokenReplacementSlot / concreteValueReplacementSlot
conceptReplacementSlot = "[[" ws "+" ws "id" ws [ "(" ws expressionConstraint ws ")" ws] [slotName ws] "]]"
...
templateInformationSlot = "[[" ws slotInformation ws "]]"
slotInformation = [cardinality ws] [slotName ws]
...
slotName = "@" (nonQuoteStringValue / slotString)
```

External stakeholders who would like to implement support for ETL must depend on the first official and currently available language specification v1.0 (http://snomed.org/sts)

[According to](https://confluence.ihtsdotools.org/display/DOCSTS/3.1.+General+SNOMED+CT+Language+Requirements) the General SNOMED CT Language Requirements:

> Requirement G.1: Backward compatibility
> 
> The language must be backwardly compatible with any version of the language that has previously been adopted as an IHTSDO standard. Please note that this requirement is not applicable to this version of the Template Syntax, as no previous version has been published as an IHTSDO standard.

A grammar parser implemented against ETL v1.0 specification would fail if the current format of `CT guided [procedure] of [body structure] (procedure)` is kept, hence this pull request to fix this one occasion where a slot reference is used.

Using the same slot name multiple times is allowed according to the [specification](https://confluence.ihtsdotools.org/display/DOCSTS/8.4.+Named+Replacement+Slots):

> Slot names may be repeated within a template. When the same slot name is associated with more than one slot in the same template, it indicates that these slots must be populated with the same value.

P.S.: the cardinality format is also different between the two versions e.g. [1..1] vs [~1..1] but that one is much easier to bypass compared to the above.